### PR TITLE
Add fairlearn to the sprints

### DIFF
--- a/content/about/sprints.md
+++ b/content/about/sprints.md
@@ -28,3 +28,4 @@ Below is the list of projects that will be participating in the sprint. If you a
 e.g. ```<<Project name with link to project repo>> (contact: <<@DiscordHandle>>, active timezone: <<AMER/EMEA/APAC>>)```
 
 - [Nawhals](https://github.com/narwhals-dev/narwhals) (contact: @Cheukting, active timezone: EMEA)
+- [Fairlearn](https://github.com/fairlearn/fairlearn) (contact: @tamaraatanasoska active timezone EMEA)


### PR DESCRIPTION
This PR adds the project [fairlearn](https://github.com/fairlearn/fairlearn) to the sprints. I am one of the maintainers and I am available to mentor on Saturday the 7th.

cc @mjmolina